### PR TITLE
fix(ci): Move to ibiqlik yamllint action

### DIFF
--- a/.github/workflows/simple-checks.yaml
+++ b/.github/workflows/simple-checks.yaml
@@ -34,12 +34,11 @@ jobs:
 
       - name: 'Yamllint'
         if: ${{ steps.filter.outputs.yaml == 'true' }}
-        uses: karancode/yamllint-github-action@master
+        uses: ibiqlik/action-yamllint@v3
         with:
-          yamllint_file_or_dir: '${{ steps.filter.outputs.yaml_files }}'
-          yamllint_strict: false
-          yamllint_comment: true
-          yamllint_config_filepath: .github/lint/yamllint.yaml
+          file_or_dir: '${{ steps.filter.outputs.yaml_files }}'
+          strict: false
+          config_file: .github/lint/yamllint.yaml
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
karancode version is broken installing pyyaml:
https://github.com/rtrox/containers/actions/runs/5577949939/jobs/10191451053

https://github.com/karancode/yamllint-github-action/issues/25

Move to ibiqlik version, which has more stars, and appears to currently be working.